### PR TITLE
Use SSH config entry if it exists + optional rsvg-convert support

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,27 +1,34 @@
 # Collection of tools for the reMarkable paper tablet
+
 ## rM2svg
+
 Convert a .lines file to an svg file
 
-```
-usage: rM2svn [-h] -i FILENAME -o NAME
+    usage: rM2svn [-h] -i FILENAME -o NAME
 
-optional arguments:
-  -h, --help                      show this help message and exit
-  -i FILENAME, --input FILENAME   .lines input file
-  -o NAME, --output NAME          prefix for output file
-  --version                       show program's version number and exit
-```
+    optional arguments:
+      -h, --help                      show this help message and exit
+      -i FILENAME, --input FILENAME   .lines input file
+      -o NAME, --output NAME          prefix for output file
+      --version                       show program's version number and exit
 
 ## exportNotebook
+
 Convert a Notebook to a PDF file: Searches for the most recent Notebook whose visible name contains NAME, and export it as PDF file.
 
+    usage: exportNotebook NAME
 
-```
-usage: exportNotebook NAME
+    $ exportNotebook Jour
+    Exporting notebook "Journal" (4 pages)
+    Journal.pdf
 
-$ exportNotebook Jour
-Exporting notebook "Journal" (4 pages)
-Journal.pdf
-```
+### SSH configuration
 
+The `exportNotebook` script assumes a USB connection. If you are connected via
+WiFi, you can add an entry to your `~/.ssh/config`:
 
+    host remarkable
+           Hostname 10.11.99.1 # or any other IP
+           User root
+           ForwardX11 no
+           ForwardAgent no

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -4,6 +4,7 @@
 # - ssh and scp (openssh)
 # - convert (imagemagick)
 # - pdftk (pdftk)
+# - rsvg-convert (optional, to avoid rasterizing of lines)
 
 # Check if ssh configuration for "remarkable" exists
 grep -Fxq "host remarkable" ~/.ssh/config
@@ -39,10 +40,17 @@ sed -e "s|^|\"${tmpfolder}\"/\"|" -e 's|$|.png"|' "${tmpfolder}"/*.pagedata | tr
 
 # Extract annotations and create a PDF
 rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground"
-convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
+
+if type "rsvg-convert" > /dev/null
+  then
+    convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
+  else
+    rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
+fi
 
 pdftk "${tmpfolder}"/foreground.pdf multibackground "${tmpfolder}"/background.pdf output "${filename//\"/}.pdf"
 
-ls "${filename//\"/}.pdf"
+filesize=$(ls -la "${filename//\"/}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
+echo "Written ${filesize} to ${filename//\"/}.pdf"
 
 rm -Rf "${tmpfolder}"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -5,15 +5,23 @@
 # - convert (imagemagick)
 # - pdftk (pdftk)
 
+# Check if ssh configuration for "remarkable" exists
+grep -Fxq "host remarkable" ~/.ssh/config
+if [ $? -eq 0 ]; then
+    SSH_IP="root@remarkable"
+else
+    SSH_IP="root@10.11.99.1"
+fi
+
 # Getting the notebook prefix (Newest notebook matching the name)
-id=$(ssh root@10.11.99.1 "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
+id=$(ssh ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
 
 test -z "$id" && exit 1
 
 tmpfolder=$(mktemp -d)
 
 # Getting notebook data
-scp -q root@10.11.99.1:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
+scp -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
 
 # Fix empty lines in pagedata files
 sed -i -e "s/^[[:blank:]]*$/Blank/" "${tmpfolder}"/*.pagedata
@@ -23,7 +31,7 @@ echo "Exporting notebook ${filename} ($(wc -l "${tmpfolder}"/*.pagedata | cut -d
 
 # Getting template files
 sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
-  scp -q root@10.11.99.1:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
+  scp -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
 done
 
 # Generate a PDF file out of the templates


### PR DESCRIPTION
First of all, thanks for your work! These scripts are exactly what I was looking for.

This PR alters `exportNotebook` to check, if the ssh config has a "remarkable" entry. If so, this is used in preference over the default USB IP. A corresponding info note is also added to the Readme.

In addition `rsvg-convert` is optionally used, if present, instead of `convert` to avoid rasterizing lines with 100 dpi. This can result in smaller filesizes, which are now also printed in the output.

```
Exporting notebook "Test" (2 pages)
Written 78,891KiB to Test.pdf
```