### PR TITLE
Fix for single-page notebooks with no background

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,27 +1,34 @@
 # Collection of tools for the reMarkable paper tablet
+
 ## rM2svg
+
 Convert a .lines file to an svg file
 
-```
-usage: rM2svn [-h] -i FILENAME -o NAME
+    usage: rM2svn [-h] -i FILENAME -o NAME
 
-optional arguments:
-  -h, --help                      show this help message and exit
-  -i FILENAME, --input FILENAME   .lines input file
-  -o NAME, --output NAME          prefix for output file
-  --version                       show program's version number and exit
-```
+    optional arguments:
+      -h, --help                      show this help message and exit
+      -i FILENAME, --input FILENAME   .lines input file
+      -o NAME, --output NAME          prefix for output file
+      --version                       show program's version number and exit
 
 ## exportNotebook
+
 Convert a Notebook to a PDF file: Searches for the most recent Notebook whose visible name contains NAME, and export it as PDF file.
 
+    usage: exportNotebook NAME
 
-```
-usage: exportNotebook NAME
+    $ exportNotebook Jour
+    Exporting notebook "Journal" (4 pages)
+    Journal.pdf
 
-$ exportNotebook Jour
-Exporting notebook "Journal" (4 pages)
-Journal.pdf
-```
+### SSH configuration
 
+The `exportNotebook` script assumes a USB connection. If you are connected via
+WiFi, you can add an entry to your `~/.ssh/config`:
 
+    host remarkable
+           Hostname 10.11.99.1 # or any other IP
+           User root
+           ForwardX11 no
+           ForwardAgent no

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -5,15 +5,23 @@
 # - convert (imagemagick)
 # - pdftk (pdftk)
 
+# Check if ssh configuration for "remarkable" exists
+grep -Fxq "host remarkable" ~/.ssh/config
+if [ $? -eq 0 ]; then
+    SSH_IP="root@remarkable"
+else
+    SSH_IP="root@10.11.99.1"
+fi
+
 # Getting the notebook prefix (Newest notebook matching the name)
-id=$(ssh root@10.11.99.1 "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
+id=$(ssh ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
 
 test -z "$id" && exit 1
 
 tmpfolder=$(mktemp -d)
 
 # Getting notebook data
-scp -q root@10.11.99.1:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
+scp -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
 
 # Fix empty lines in pagedata files
 sed -i -e "s/^[[:blank:]]*$/Blank/" "${tmpfolder}"/*.pagedata
@@ -23,7 +31,7 @@ echo "Exporting notebook ${filename} ($(wc -l "${tmpfolder}"/*.pagedata | cut -d
 
 # Getting template files
 sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
-  scp -q root@10.11.99.1:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
+  scp -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
 done
 
 # Generate a PDF file out of the templates

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -23,6 +23,12 @@ tmpfolder=$(mktemp -d)
 # Getting notebook data
 scp -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
 
+# Fix for single page notebooks with no template (empty pagedata file by default)
+if [ ! -s "${tmpfolder}"/*.pagedata ]
+then
+  echo "Blank" > "${tmpfolder}"/*.pagedata
+fi
+
 # Fix empty lines in pagedata files
 sed -i -e "s/^[[:blank:]]*$/Blank/" "${tmpfolder}"/*.pagedata
 


### PR DESCRIPTION
`exportNotebook` did not work for single-page notebooks with blank background directly after creation (it did work after adding and deleting a second page). For these case, i.e. when the pagedata file is empty, this PR adds a "Blank" line to the file.