### PR TITLE
Support for document annotations

### DIFF
--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -24,6 +24,9 @@ tmpfolder=$(mktemp -d)
 # Getting notebook data
 scp -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
 
+# Copy underyling document pdf if it exists
+ssh -q ${SSH_IP} "[[ -f "${id}.pdf" ]]" && scp -q ${SSH_IP}:"${id}.pdf" "${tmpfolder}"
+
 # Fix for single page notebooks with no template (empty pagedata file by default)
 if [ ! -s "${tmpfolder}"/*.pagedata ]
 then
@@ -36,21 +39,27 @@ sed -i -e "s/^[[:blank:]]*$/Blank/" "${tmpfolder}"/*.pagedata
 filename=$(grep -F  '"visibleName"' "${tmpfolder}"/*.metadata | cut -d: -f2- | grep -o '"[^"]*"')
 echo "Exporting notebook ${filename} ($(wc -l "${tmpfolder}"/*.pagedata | cut -d\  -f1) pages)"
 
-# Getting template files
-sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
-  scp -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
-done
+if [ -f "${tmpfolder}"/*.pdf ]
+then
+    echo "Found underlying document PDF, using as background."
+    cp "${tmpfolder}/"*.pdf "${tmpfolder}/background.pdf"
+else
+    # Getting template files
+    sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
+    scp -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
+    done
 
-# Generate a PDF file out of the templates
-sed -e "s|^|\"${tmpfolder}\"/\"|" -e 's|$|.png"|' "${tmpfolder}"/*.pagedata | tr '\n' ' ' | sed -e "s|$|-transparent white \"${tmpfolder}\"/background.pdf|" | xargs convert
+    # Generate a PDF file out of the templates
+    sed -e "s|^|\"${tmpfolder}\"/\"|" -e 's|$|.png"|' "${tmpfolder}"/*.pagedata | tr '\n' ' ' | sed -e "s|$|-transparent white \"${tmpfolder}\"/background.pdf|" | xargs convert
+fi
 
 # Extract annotations and create a PDF
 rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground"
 
 if type "rsvg-convert" > /dev/null
-  then
+then
     convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
-  else
+else
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
 fi
 

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -64,9 +64,9 @@ rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 
 if type "rsvg-convert" > /dev/null
 then
-    convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
-else
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
+else
+    convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
 fi
 
 # Strip .pdf suffix if it already exists (document vs. notebook)

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -8,6 +8,7 @@
 
 if [[ $# -eq 0 ]] ; then
     echo "Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments"
+    echo "You can additionally append the -c argument for coloured annotations."
     exit 0
 fi
 

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -6,6 +6,11 @@
 # - pdftk (pdftk)
 # - rsvg-convert (optional, to avoid rasterizing of lines)
 
+if [[ $# -eq 0 ]] ; then
+    echo "Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments"
+    exit 0
+fi
+
 # Check if ssh configuration for "remarkable" exists
 grep -Fxq "host remarkable" ~/.ssh/config
 if [ $? -eq 0 ]; then
@@ -54,7 +59,7 @@ else
 fi
 
 # Extract annotations and create a PDF
-rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground"
+rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 
 if type "rsvg-convert" > /dev/null
 then
@@ -63,9 +68,13 @@ else
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
 fi
 
-pdftk "${tmpfolder}"/foreground.pdf multibackground "${tmpfolder}"/background.pdf output "${filename//\"/}.pdf"
+# Strip .pdf suffix if it already exists (document vs. notebook)
+filename=$(basename -s .pdf ${filename//\"/})
 
-filesize=$(ls -la "${filename//\"/}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
-echo "Written ${filesize} to ${filename//\"/}.pdf"
+# Use multistamp instead of multibackground to preserve transparency
+pdftk "${tmpfolder}"/foreground.pdf multistamp "${tmpfolder}"/background.pdf output "${filename}.pdf"
+
+filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
+echo "Written ${filesize} to ${filename}.pdf"
 
 rm -Rf "${tmpfolder}"

--- a/tools/rM2svg
+++ b/tools/rM2svg
@@ -14,15 +14,16 @@ x_width = 1404
 y_width = 1872
 
 # Mappings
-stroke_colour={
-    0 : "black",
-    1 : "grey",
-    2 : "white",
-}
+stroke_colour = {
+    0: "black",
+    1: "grey",
+    2: "white",
+    }
+
 '''stroke_width={
-    0x3ff00000 : 2,
-    0x40000000 : 4,
-    0x40080000 : 8,
+    0x3ff00000: 2,
+    0x40000000: 4,
+    0x40080000: 8,
 }'''
 
 
@@ -47,6 +48,11 @@ def main():
                         metavar="NAME",
                         #type=argparse.FileType('w')
                         )
+    parser.add_argument("-c",
+                        "--coloured_annotations",
+                        help="Colour annotations for document markup.",
+                        action='store_true',
+                        )
     parser.add_argument('--version',
                         action='version',
                         version='%(prog)s {version}'.format(version=__version__))
@@ -55,7 +61,16 @@ def main():
     if not os.path.exists(args.input):
         parser.error('The file "{}" does not exist!'.format(args.input))
 
-    lines2svg(args.input, args.output, args.singlefile)
+    if args.coloured_annotations:
+        global stroke_colour
+        stroke_colour = {
+            0: "blue",
+            1: "red",
+            2: "white",
+            3: "yellow"
+        }
+
+    lines2svg(args.input, args.output, args.singlefile, args.coloured_annotations)
 
 
 def abort(msg):
@@ -63,7 +78,7 @@ def abort(msg):
     sys.exit(1)
 
 
-def lines2svg(input_file, output_name, singlefile):
+def lines2svg(input_file, output_name, singlefile, coloured_annotations=False):
     # Read the file in memory. Consider optimising by reading chunks.
     with open(input_file, 'rb') as f:
         data = f.read()
@@ -132,6 +147,8 @@ def lines2svg(input_file, output_name, singlefile):
                 elif pen == 5: # Highlighter
                     width = 30
                     opacity = 0.2
+                    if coloured_annotations:
+                        colour = 3
                 elif pen == 6: # Eraser
                     width = 1280 * width * width - 4800 * width + 4510
                     colour = 2
@@ -140,7 +157,7 @@ def lines2svg(input_file, output_name, singlefile):
                     opacity = 0.9
                 elif pen == 8: # Erase area
                     opacity = 0.
-                else: 
+                else:
                     print('Unknown pen: {}'.format(pen))
                     opacity = 0.
 


### PR DESCRIPTION
`exportNotebook` works great for handwritten notes, but not for annotations made within a document pdf. In such cases one currently get's a blank PDF with annotations only, i.e. without the underlying document. This PR changes this by:

- checking if `${id$}.pdf` exists and using it as `background.pdf` instead of performing template conversion
- ensuring that transparency is preserved by using the pdftk argument `multistamp` instead of `multipage`
- Stripping redundant `.pdf` suffix if it already exists in `$filename`
- Optionally allowing for colored annotations by an additional rMsvg argument `--coloured_annotations` or simply `-c`
- Passing these (and any other additional) arguments from `exportNotebook` to `rMsvg`
- (Fixing some PEP8 in rMsvg)

# Examples

## Small help message if no argument is provided
```
$ ~ exportNotebook           
Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments
You can additionally append the -c argument for coloured annotations.
```

## Normal behavior
Calling `exportNotebook remarkable` works as expected, i.e. uses the underlying pdf as the background and not a succesion of Blank templates: 
[remarkable.pdf](https://github.com/reHackable/maxio/files/1695103/remarkable.pdf)

## Custom behavior
Calling `exportNotebook remarkable -c` creates the following: 
[remarkable-c.pdf](https://github.com/reHackable/maxio/files/1695105/remarkable-c.pdf)

## Current limitations
If the PDF was cropped, the annotations are shifted. I haven't figured out where the crop information is stored and how the foreground.pdf can be transformed accordingly. Anyone has an idea?

Please consider merging. It think this could be of value for a lot of users who use the remarkable to annotate academic PDFs.
