### PR TITLE
fix binary check for rsvg-convert

### DIFF
--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -62,7 +62,7 @@ fi
 # Extract annotations and create a PDF
 rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 
-if type "rsvg-convert" > /dev/null
+if command -v "rsvg-convert" > /dev/null
 then
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
 else


### PR DESCRIPTION
On Debian Stretch the command 'type rsvg-convert > /dev/null' returns 1
even when the binary is not present in the system. As suggested here:

https://stackoverflow.com/a/677212

use 'command -v' to check for the binary.