### PR TITLE
Account for dimensions of background pdf

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -6,7 +6,7 @@ The following binaries are required running these tools:
  * ssh
  * scp
  * convert or rsvg-convert
- * optional: ghostscript and identify to account for original pdf dimensions
+ * optional: ghostscript and pdfinfo to account for original pdf dimensions
 
 If you are using a Debian-based Linux system, the following command should
 install all requirements:

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,11 +6,12 @@ The following binaries are required running these tools:
  * ssh
  * scp
  * convert or rsvg-convert
+ * optional: ghostscript and identify to account for original pdf dimensions
 
 If you are using a Debian-based Linux system, the following command should
 install all requirements:
 
-	sudo apt-get install python3 librsvg2-bin pdftk openssh-client
+	sudo apt-get install python3 librsvg2-bin pdftk openssh-client ghostscript
 
 ## rM2svg
 

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -5,6 +5,7 @@
 # - convert (imagemagick)
 # - pdftk (pdftk)
 # - rsvg-convert (optional, to avoid rasterizing of lines)
+# - gs & identify (optional, to account for original pdf size)
 
 if [[ $# -eq 0 ]] ; then
     echo "Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments"
@@ -47,8 +48,32 @@ echo "Exporting notebook ${filename} ($(wc -l "${tmpfolder}"/*.pagedata | cut -d
 
 if [ -f "${tmpfolder}"/*.pdf ]
 then
+    ln -s "${tmpfolder}/"*.pdf "${tmpfolder}/background_original.pdf"
     echo "Found underlying document PDF, using as background."
-    cp "${tmpfolder}/"*.pdf "${tmpfolder}/background.pdf"
+
+    if command -v "gs" > /dev/null && command -v "identify" > /dev/null
+    then
+        # Read PDF dimensions for scale correction
+        size=$(identify ${tmpfolder}/background_original.pdf | awk '{print $3}')
+        width=$(echo ${size} | cut -f1 -dx)
+        height=$(echo ${size} | cut -f2 -dx)
+
+        # Calculate new width and necessary offset (rM dimensions: 1404x1872)
+        new_width=$(echo "scale=5; ${height} / 1872 * 1404" | bc)
+        echo "new width, ${new_width}"
+        offset=$(echo "scale=5; ${new_width} - ${width}" | bc)
+        echo "Original PDF dimensions are ${size}, correcting by offset of ${offset} to fit rM foreground."
+
+        # Add offset to background.pdf to match foreground dimensions
+        gs -q -sDEVICE=pdfwrite -dBATCH -dNOPAUSE -sOutputFile=${tmpfolder}/background_with_offset.pdf \
+        -dDEVICEWIDTHPOINTS=${new_width} -dDEVICEHEIGHTPOINTS=${height} -dFIXEDMEDIA \
+        -c "{${offset} 0 translate}" \
+        -f "${tmpfolder}/background_original.pdf"
+
+        ln -s ${tmpfolder}/background_with_offset.pdf ${tmpfolder}/background.pdf
+    else
+        ln -s ${tmpfolder}/background_original.pdf ${tmpfolder}/background.pdf
+    fi
 else
     # Getting template files
     sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
@@ -73,7 +98,7 @@ fi
 filename=$(basename -s .pdf ${filename//\"/})
 
 # Use multistamp instead of multibackground to preserve transparency
-pdftk "${tmpfolder}"/foreground.pdf multistamp "${tmpfolder}"/background.pdf output "${filename}.pdf"
+pdftk "${tmpfolder}"/background.pdf multistamp "${tmpfolder}"/foreground.pdf output "${filename}.pdf"
 
 filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
 echo "Written ${filesize} to ${filename}.pdf"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -60,7 +60,6 @@ then
 
         # Calculate new width and necessary offset (rM dimensions: 1404x1872)
         new_width=$(echo "scale=5; ${height} / 1872 * 1404" | bc)
-        echo "new width, ${new_width}"
         offset=$(echo "scale=5; ${new_width} - ${width}" | bc)
         echo "Original PDF dimensions are ${size}, correcting by offset of ${offset} to fit rM foreground."
 

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -5,7 +5,7 @@
 # - convert (imagemagick)
 # - pdftk (pdftk)
 # - rsvg-convert (optional, to avoid rasterizing of lines)
-# - gs & identify (optional, to account for original pdf size)
+# - gs & pdfinfo (optional, to account for original pdf size)
 
 if [[ $# -eq 0 ]] ; then
     echo "Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments"
@@ -51,17 +51,18 @@ then
     ln -s "${tmpfolder}/"*.pdf "${tmpfolder}/background_original.pdf"
     echo "Found underlying document PDF, using as background."
 
-    if command -v "gs" > /dev/null && command -v "identify" > /dev/null
+    if command -v "gs" > /dev/null && command -v "pdfinfo" > /dev/null
     then
         # Read PDF dimensions for scale correction
-        size=$(identify ${tmpfolder}/background_original.pdf | awk '{print $3}')
-        width=$(echo ${size} | cut -f1 -dx)
-        height=$(echo ${size} | cut -f2 -dx)
+        size=$(pdfinfo ${tmpfolder}/background_original.pdf | grep "Page size" | awk '{print $3,$5}')
+        width=$(echo ${size} | cut -f1 -d " ")
+        height=$(echo ${size} | cut -f2 -d " ")
 
         # Calculate new width and necessary offset (rM dimensions: 1404x1872)
         new_width=$(echo "scale=5; ${height} / 1872 * 1404" | bc)
         offset=$(echo "scale=5; ${new_width} - ${width}" | bc)
-        echo "Original PDF dimensions are ${size}, correcting by offset of ${offset} to fit rM foreground."
+
+        echo "Original PDF dimensions are (${width}x${height}), correcting by offset of ${offset} to fit rM foreground."
 
         # Add offset to background.pdf to match foreground dimensions
         gs -q -sDEVICE=pdfwrite -dBATCH -dNOPAUSE -sOutputFile=${tmpfolder}/background_with_offset.pdf \


### PR DESCRIPTION
I originally thought it was due to cropping on the reMarkable, but the dimensions of the device simply differ from DIN A4 documents, such that notes on such documents are currently shifted. This PR takes into account the original pdf size and adds a corresponding margin to the right hand side, such that `background.pdf` and `foreground.pdf` have the same dimensions and notes are properly aligned.

*Note: This is not affected by cropping, yet currently only tested with Din A4 portrait documents*

# Example
- [Original background PDF (DIN A4 dimensions)](https://github.com/reHackable/maxio/files/1717211/original.pdf)
- [Export with current master](https://github.com/reHackable/maxio/files/1717212/current_master.pdf)
- [Export after this pull request](https://github.com/reHackable/maxio/files/1717220/this_pull_request.pdf)

## Additional minor changes
- Introduce symlinks instead of copying `$ID.pdf` to `background.pdf`, which is more performant for large pdfs (i.e. books).
- Due to the change from pdftk arguments `multibackground` to `multistamp` (which accounts for transparency), the foreground and background were flipped (hardly noticeable due to transparent templates). This is also fixed in this PR.


