### PR TITLE
Improve ssh and path

### DIFF
--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -20,18 +20,23 @@ else
     SSH_IP="root@10.11.99.1"
 fi
 
+# Start SSH in ControlMaster mode
+control_path_dir=$(mktemp -d --suffix=ssh_remark)
+control_options="-o ControlPath=$control_path_dir/%h_%p_%r -o ControlPersist=10s"
+ssh -M ${control_options} ${SSH_IP} exit
+
 # Getting the notebook prefix (Newest notebook matching the name)
-id=$(ssh ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
+id=$(ssh ${control_options} ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
 
 test -z "$id" && exit 1
 
 tmpfolder=$(mktemp -d)
 
 # Getting notebook data
-scp -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
+scp $control_options -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
 
 # Copy underyling document pdf if it exists
-ssh -q ${SSH_IP} "[[ -f "${id}.pdf" ]]" && scp -q ${SSH_IP}:"${id}.pdf" "${tmpfolder}"
+ssh $control_options -q ${SSH_IP} "[[ -f "${id}.pdf" ]]" && scp $control_options -q ${SSH_IP}:"${id}.pdf" "${tmpfolder}"
 
 # Fix for single page notebooks with no template (empty pagedata file by default)
 if [ ! -s "${tmpfolder}"/*.pagedata ]
@@ -52,7 +57,7 @@ then
 else
     # Getting template files
     sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
-    scp -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
+    scp $control_options -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
     done
 
     # Generate a PDF file out of the templates
@@ -78,4 +83,5 @@ pdftk "${tmpfolder}"/foreground.pdf multistamp "${tmpfolder}"/background.pdf out
 filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
 echo "Written ${filesize} to ${filename}.pdf"
 
-rm -Rf "${tmpfolder}"
+ssh $control_options -O exit ${SSH_IP}
+rm -Rf "${tmpfolder}" "${control_path_dir}"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -12,6 +12,19 @@ if [[ $# -eq 0 ]] ; then
     exit 0
 fi
 
+# Make sure we have rM2svg
+command -v rM2svg >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    if [[ -x rM2svg ]]; then
+        rM2svg_cmd="$(dirname `readlink -f $0`)/rM2svg"
+    else
+        print "Cannot find rM2svg"
+        exit 1
+    fi
+else
+    rM2svg_cmd="rM2svg"
+fi
+
 # Check if ssh configuration for "remarkable" exists
 grep -Fxq "host remarkable" ~/.ssh/config
 if [ $? -eq 0 ]; then
@@ -65,7 +78,7 @@ else
 fi
 
 # Extract annotations and create a PDF
-rM2svg --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
+$rM2svg_cmd --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 
 if command -v "rsvg-convert" > /dev/null
 then


### PR DESCRIPTION
I've made a few simple improvements to make the `exportNotebook` script easier to use:

* SSH connections use `ControlMaster` mode to request authentication only once
* `rM2svg` can be run if in `$PATH` or if present in the same directory as `exportNotebook`