### PR TITLE
exportNotebook: use env in shebang

### DIFF
--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Needs:
 # - ssh and scp (openssh)


### PR DESCRIPTION
In non FHS-compilant filesystems, binaries are not available in the usual paths. Use env to load the right application.