### PR TITLE
Add support for exporting annotated pdfs

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -6,12 +6,14 @@ The following binaries are required running these tools:
  * ssh
  * scp
  * convert or rsvg-convert
+ * bc
  * optional: ghostscript and pdfinfo to account for original pdf dimensions
+ * pdfjam
 
 If you are using a Debian-based Linux system, the following command should
 install all requirements:
 
-	sudo apt-get install python3 librsvg2-bin pdftk openssh-client ghostscript
+	sudo apt-get install python3 librsvg2-bin pdftk openssh-client ghostscript pdfjam poppler-utils bc
 
 ## rM2svg
 
@@ -36,6 +38,28 @@ visible name contains NAME, and exports it as PDF file. Works also for
     $ exportNotebook Jour
     Exporting notebook "Journal" (4 pages)
     Journal.pdf
+
+## exportDocument
+
+Export an annotated PDF file.
+
+    usage: Usage: exportDocument <input_file.lines> <ouput.pdf>
+
+The command expects the original PDF file <foo>.pdf to be present in the same
+directory as <foo>.lines. This would be the case if you had copied the entire
+`xochitl` directory from your reMarkable tablet to the development machine.
+A typical workflow would be:
+
+```bash
+$ scp -r root@10.11.99.1:/home/root/.local/share/remarkable/xochitl .
+$ cd xochitl
+```
+
+Say `f073469b-d37c-432f-84d1-45fdaf12400b.lines` containts the annotations of
+the interested file. The original filename can be found in the `visibleName`
+field in `f073469b-d37c-432f-84d1-45fdaf12400b.metadata`.
+
+$ exportDocument f073469b-d37c-432f-84d1-45fdaf12400b.lines out.pdf
 
 ### SSH configuration
 

--- a/tools/exportDocument
+++ b/tools/exportDocument
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if [ -z "$1" ] || [ -z "$2" ]
+  then
+    echo "Usage: $0 <input_file.lines> <ouput.pdf>"
+    exit 1
+fi
+
+PWD=`dirname "$0"`
+BASE=`basename $1 .lines`
+WIDTH=`pdfinfo ${BASE}.pdf | grep "Page size:" | awk '{print $3}'`
+HEIGHT=`pdfinfo ${BASE}.pdf | grep "Page size:" | awk '{print $5}'`
+OUTPUT=$2
+
+function scale_width {
+	NEW_WIDTH=`echo "${HEIGHT} * 0.75" | bc | sed "s/\..*//g"`
+	#Origin is at left bottom
+	OFFSET=`echo "(${WIDTH} - ${NEW_WIDTH}) / 2.0" | bc | sed "s/\..*//g"`
+
+	$PWD/rM2svg -c -i ${BASE}.lines -o ${BASE}.svg
+	for i in `ls ${BASE}_*.svg`
+	do
+		rsvg-convert -w ${NEW_WIDTH} -h ${HEIGHT} -f pdf $i > `sed "s/svg/pdf/g" <<< "$i"`
+	done
+
+	PDF_FILES=`ls ${BASE}_*.pdf | sort -V`
+	pdftk ${PDF_FILES} cat output ${BASE}_annotations.pdf
+	rm ${PDF_FILES}
+	rm `ls ${BASE}_*.svg`
+	pdfjam --papersize "{${NEW_WIDTH}pt,${HEIGHT}pt}" --offset "${OFFSET}pt 0pt" --outfile ${BASE}_resized.pdf ${BASE}.pdf
+	pdftk ${BASE}_resized.pdf multistamp ${BASE}_annotations.pdf output ${OUTPUT}
+	rm ${BASE}_resized.pdf ${BASE}_annotations.pdf
+}
+
+function scale_height {
+	NEW_HEIGHT=`echo "${WIDTH} * 1.3333" | bc | sed "s/\..*//g"`
+	#Origin is at left bottom
+	OFFSET=`echo "(${NEW_HEIGHT} - ${HEIGHT}) / 2.0" | bc | sed "s/\..*//g"`
+
+	$PWD/rM2svg -i ${BASE}.lines -o ${BASE}.svg
+	for i in `ls ${BASE}_*.svg`
+	do
+		rsvg-convert -w ${WIDTH} -h ${NEW_HEIGHT} -f pdf $i > `sed "s/svg/pdf/g" <<< "$i"`
+	done
+
+	PDF_FILES=`ls ${BASE}_*.pdf | sort -V`
+	pdftk ${PDF_FILES} cat output ${BASE}_annotations.pdf
+	rm ${PDF_FILES}
+	rm `ls ${BASE}_*.svg`
+	pdfjam --papersize "{${WIDTH}pt,${NEW_HEIGHT}pt}" --offset "0pt ${OFFSET}pt" --outfile ${BASE}_resized.pdf ${BASE}.pdf
+	pdftk ${BASE}_resized.pdf multistamp ${BASE}_annotations.pdf output ${OUTPUT}
+	rm ${BASE}_resized.pdf ${BASE}_annotations.pdf
+}
+
+#0.75 is the ratio of rM tablet width to height
+R=`echo "${WIDTH}.0 / ${HEIGHT} < 0.75" | bc -l`
+if [[ ${R} == 1 ]]; then
+	scale_width
+else
+	scale_height
+fi


### PR DESCRIPTION
Exporting annotated pdfs through the native apps is broken since the native export functionality does not account for the different page sizes between the tablet and the pdf. The PR introduces a script `exportDocument` to export the PDF and correct for the page sizes. Moreover, the exported pdf is not a bitmap unlike the native export functionality and retains the vector graphics. Hence, the exported pdf remains selectable and searchable. 

----
Exporting natively using the Mac app:
![screen shot 2018-04-15 at 14 22 41](https://user-images.githubusercontent.com/410484/38779409-e551d216-40bf-11e8-8377-8f7496ae0669.png)
![screen shot 2018-04-15 at 14 39 59](https://user-images.githubusercontent.com/410484/38779407-e51e32b2-40bf-11e8-9422-1f6fc3dbb510.png)
----
Export using `exportDocument`:
![screen shot 2018-04-15 at 14 34 06](https://user-images.githubusercontent.com/410484/38779408-e5377790-40bf-11e8-9322-dd48e42823d8.png)
![screen shot 2018-04-15 at 14 40 13](https://user-images.githubusercontent.com/410484/38779406-e5079cb4-40bf-11e8-9830-8c3ba48c0219.png)




