### PR TITLE
Make exportNotebook work with new reMarkable versions plus other features

### DIFF
--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -142,7 +142,7 @@ else
     rM2svg_cmd="rM2svg"
 fi
 
-[ -n $COLOR_ANNOTATIONS ] && rM2svg_cmd="$rM2svg_cmd -c"
+[ -n "$COLOR_ANNOTATIONS" ] && rM2svg_cmd="$rM2svg_cmd -c"
 
 tmpfolder=$(mktemp -d)
 echo "Using temp folder '$tmpfolder'"
@@ -150,7 +150,8 @@ echo "Using temp folder '$tmpfolder'"
 OUTPUT_UUID=""
 
 if [ -f "$path" ]; then
-    tar -xvzf "$path" -C "$tmpfolder" || exit 1
+    tar -xvzf "$path" -C "$tmpfolder"
+    [ ! $? -eq 0 ] && echo "File '$path' exists, but it is not a valid .tar.gz" && exit 1
     filename="$(basename $path .tar.gz)"
 
 else
@@ -361,18 +362,18 @@ else
     echo "Left temporary dir '${tmpfolder}'"
 fi
 
-if [ -n $ASK_RENAME ]; then
+if [ -n "$ASK_RENAME" ]; then
     xdg-open "${filename}.pdf"
     [ -n "$OUTPUT_UUID" ] && echo "Last modified: ${DOCUMENTS_DATES[$OUTPUT_UUID]}"
     echo
-    read -rp "New name w/o extension, or press Enter to delete files: " NEWFILENAME
+    read -rp "New name w/o extension, '!rm' to delete files, Enter to skip: " NEWFILENAME
     echo
     if [ -n "$NEWFILENAME" ]; then
-        mv -vi "${filename}.pdf" "${NEWFILENAME}.pdf"
-        mv -vi "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
-        filename="${NEWFILENAME}"
-    else
-        rm -v "${filename}.pdf" "${filename}.tar.gz"
+        if [ "$NEWFILENAME" == "!rm" ]; then
+            rm -v "${filename}.pdf" "${filename}.tar.gz"
+        else
+            mv -vi "${filename}.pdf" "${NEWFILENAME}.pdf"
+            mv -vi "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
+        fi
     fi
 fi
-

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -16,10 +16,9 @@ fi
 # Make sure we have rM2svg
 command -v rM2svg >/dev/null 2>&1
 if [[ $? -ne 0 ]]; then
-    if [[ -x rM2svg ]]; then
-        rM2svg_cmd="$(dirname `readlink -f $0`)/rM2svg"
-    else
-        print "Cannot find rM2svg"
+    rM2svg_cmd="$(dirname `readlink -f $0`)/rM2svg"
+    if [[ ! -x ${rM2svg_cmd} ]]; then
+        echo "Cannot find rM2svg"
         exit 1
     fi
 else
@@ -33,22 +32,32 @@ SSH_IP="root@$1"
 shift
 
 # Start SSH in ControlMaster mode
-control_path_dir=$(mktemp -d --suffix=ssh_remark)
-control_options="-o ControlPath=$control_path_dir/%h_%p_%r -o ControlPersist=10s"
-ssh -M ${control_options} ${SSH_IP} exit
+ssh_cmd="ssh -o ControlPersist=10s"
+scp_cmd=scp
+rm_tmpfolders="rm -Rf \"${tmpfolder}\""
+
+grep ControlPath ~/.ssh/config >/dev/null
+if [ ! $? -eq 0 ]; then
+    control_path_dir=$(mktemp -d --suffix=ssh_remark)
+    control_options="-o ControlPath=$control_path_dir/%h_%p_%r"
+    rm_tmpfolders="${rm_tmpfolders} \"${control_path_dir}\""
+    ssh_cmd="${ssh_cmd} ${control_options}"
+    scp_cmd="${scp_cmd} ${control_options}"    
+fi
+${ssh_cmd} ${SSH_IP} exit
 
 # Getting the notebook prefix (Newest notebook matching the name)
-id=$(ssh ${control_options} ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
+id=$(${ssh_cmd} -M ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
 
 test -z "$id" && exit 1
 
 tmpfolder=$(mktemp -d)
 
 # Getting notebook data
-scp $control_options -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
+${scp_cmd} -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
 
 # Copy underyling document pdf if it exists
-ssh $control_options -q ${SSH_IP} "[[ -f "${id}.pdf" ]]" && scp $control_options -q ${SSH_IP}:"${id}.pdf" "${tmpfolder}"
+${ssh_cmd} -q ${SSH_IP} "[[ -f "${id}.pdf" ]]" && ${scp_cmd} -q ${SSH_IP}:"${id}.pdf" "${tmpfolder}"
 
 # Fix for single page notebooks with no template (empty pagedata file by default)
 if [ ! -s "${tmpfolder}"/*.pagedata ]
@@ -93,7 +102,7 @@ then
 else
     # Getting template files
     sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
-    scp $control_options -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
+    ${scp_cmd} -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
     done
 
     # Generate a PDF file out of the templates
@@ -103,8 +112,10 @@ fi
 # Extract annotations and create a PDF
 $rM2svg_cmd --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 
-if command -v "rsvg-convert" > /dev/null
-then
+
+if command -v "inkscape" > /dev/null; then
+    inkscape "${tmpfolder}"/foreground*.svg --export-pdf="${tmpfolder}"/foreground.pdf
+elif command -v "rsvg-convert" > /dev/null; then
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
 else
     convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
@@ -119,5 +130,5 @@ pdftk "${tmpfolder}"/background.pdf multistamp "${tmpfolder}"/foreground.pdf out
 filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
 echo "Written ${filesize} to ${filename}.pdf"
 
-ssh $control_options -O exit ${SSH_IP}
-rm -Rf "${tmpfolder}" "${control_path_dir}"
+${ssh_cmd} -O exit ${SSH_IP}
+${rm_tmpfolders}

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -231,7 +231,7 @@ fi
 
 # Extract annotations and create a PDF
 IPAGE=0
-jq '.pages' sandbox/ad41a482-16ee-4389-a7e2-9f8d444d8518.content | jq '.[]' | while read -r page; do
+jq '.pages' "${tmpfolder}"/*.content | jq '.[]' | while read -r page; do
     SPAGE="${page:1:${#page}-2}"
     let IPAGE=IPAGE+1
     echo "Processing page $IPAGE ($SPAGE)"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -51,6 +51,7 @@ while [[ $# -gt 0 ]]; do
         -*)
             echo "Unknown option: $1"
             bad_args=TRUE
+            shift
             ;;
         *)
             arg_num=$(( $arg_num + 1 ))
@@ -145,6 +146,8 @@ fi
 
 tmpfolder=$(mktemp -d)
 echo "Using temp folder '$tmpfolder'"
+
+OUTPUT_UUID=""
 
 if [ -f "$path" ]; then
     tar -xvzf "$path" -C "$tmpfolder"
@@ -291,9 +294,26 @@ IPAGE=0
 jq '.pages' "${tmpfolder}"/*.content | jq '.[]' | while read -r page; do
     SPAGE="${page:1:${#page}-2}"
     let IPAGE=IPAGE+1
-    echo "Processing page $IPAGE ($SPAGE)"
-    $rM2svg_cmd --input "${tmpfolder}"/*/"${SPAGE}.rm" --output "${tmpfolder}/foreground$(printf %03d $IPAGE).svg"
-    [ ! $? -eq 0 ] && echo "Failed to generate '${tmpfolder}/foreground$(printf %03d $IPAGE).svg'" && exit 1
+    if [ -f "${tmpfolder}"/*/"${SPAGE}.rm" ]; then
+        echo "Processing page $IPAGE ($SPAGE)"
+        $rM2svg_cmd --input "${tmpfolder}"/*/"${SPAGE}.rm" --output "${tmpfolder}/foreground$(printf %03d $IPAGE).svg"
+        [ ! $? -eq 0 ] && echo "Failed to generate '${tmpfolder}/foreground$(printf %03d $IPAGE).svg'" && exit 1
+    else
+        echo "Generating empty page $IPAGE ($SPAGE)"
+cat << 'EOF' > "${tmpfolder}/foreground$(printf %03d $IPAGE).svg"
+<svg xmlns="http://www.w3.org/2000/svg" height="1872" width="1404">
+        <script type="application/ecmascript"> <![CDATA[
+            var visiblePage = 'p1';
+            function goToPage(page) {
+                document.getElementById(visiblePage).setAttribute('style', 'display: none');
+                document.getElementById(page).setAttribute('style', 'display: inline');
+                visiblePage = page;
+            }
+        ]]> </script>
+    <g id="p1" style="display:inline">
+<rect x="0" y="0" width="1404" height="1872" fill-opacity="0"/></g></svg>
+EOF
+    fi
 done
 
 # Preprocess foreground*.svg
@@ -333,18 +353,26 @@ pdftk "${tmpfolder}"/background.pdf multistamp "${tmpfolder}"/foreground.pdf out
 
 filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
 
-if [ ! -z $ASK_RENAME ]; then
-    xdg-open "${filename}.pdf"
-    echo
-    read -rp "New name (w/o extension): " NEWFILENAME
-    echo
-    mv -v "${filename}.pdf" "${NEWFILENAME}.pdf"
-    mv -v "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
-    filename="${NEWFILENAME}"
-fi
-
 echo "Written ${filesize} to ${filename}.pdf"
 
 if [ -z $KEEP_TEMPDIR ]; then
-    rm -Rfv "${tmpfolder}"
+    rm -Rf "${tmpfolder}"
+else
+    echo "Left temporary dir '${tmpfolder}'"
 fi
+
+if [ ! -z $ASK_RENAME ]; then
+    xdg-open "${filename}.pdf"
+    [ ! -z "$OUTPUT_UUID" ] && echo "Last modified: ${DOCUMENTS_DATES[$OUTPUT_UUID]}"
+    echo
+    read -rp "New name (w/o extension): " NEWFILENAME
+    echo
+    if [ ! -z "$NEWFILENAME" ]; then
+        mv -v "${filename}.pdf" "${NEWFILENAME}.pdf"
+        mv -v "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
+        filename="${NEWFILENAME}"
+    else
+        rm -v "${filename}.pdf" "${filename}.tar.gz"
+    fi
+fi
+

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -365,7 +365,7 @@ if [ ! -z $ASK_RENAME ]; then
     xdg-open "${filename}.pdf"
     [ ! -z "$OUTPUT_UUID" ] && echo "Last modified: ${DOCUMENTS_DATES[$OUTPUT_UUID]}"
     echo
-    read -rp "New name (w/o extension): " NEWFILENAME
+    read -rp "New name w/o extension, or press Enter to delete files: " NEWFILENAME
     echo
     if [ ! -z "$NEWFILENAME" ]; then
         mv -v "${filename}.pdf" "${NEWFILENAME}.pdf"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -142,7 +142,7 @@ else
     rM2svg_cmd="rM2svg"
 fi
 
-[ ! -z $COLOR_ANNOTATIONS ] && rM2svg_cmd="$rM2svg_cmd -c"
+[ -n $COLOR_ANNOTATIONS ] && rM2svg_cmd="$rM2svg_cmd -c"
 
 tmpfolder=$(mktemp -d)
 echo "Using temp folder '$tmpfolder'"
@@ -150,7 +150,7 @@ echo "Using temp folder '$tmpfolder'"
 OUTPUT_UUID=""
 
 if [ -f "$path" ]; then
-    tar -xvzf "$path" -C "$tmpfolder"
+    tar -xvzf "$path" -C "$tmpfolder" || exit 1
     filename="$(basename $path .tar.gz)"
 
 else
@@ -172,7 +172,7 @@ else
 
     # Entry not found
     if [ "${#DOCUMENTS_UUIDS[@]}" -eq 0 ]; then
-        echo "repull: Unable to find document: $path"
+        echo "exportNotebook: Unable to find document: $path"
         exit_failed
     fi
 
@@ -327,7 +327,7 @@ done
 if command -v "svgo" > /dev/null; then
     for f in "${tmpfolder}"/foreground*.svg; do
         svgo -i "$f"
-        [ ! $? -eq 0 ] && echo "Failed to optimize svg '$f'" && exit 1
+        [ ! $? -eq 0 ] && echo "Failed to optimize svg '$f'" && continue
     done
 fi
 
@@ -361,15 +361,15 @@ else
     echo "Left temporary dir '${tmpfolder}'"
 fi
 
-if [ ! -z $ASK_RENAME ]; then
+if [ -n $ASK_RENAME ]; then
     xdg-open "${filename}.pdf"
-    [ ! -z "$OUTPUT_UUID" ] && echo "Last modified: ${DOCUMENTS_DATES[$OUTPUT_UUID]}"
+    [ -n "$OUTPUT_UUID" ] && echo "Last modified: ${DOCUMENTS_DATES[$OUTPUT_UUID]}"
     echo
     read -rp "New name w/o extension, or press Enter to delete files: " NEWFILENAME
     echo
-    if [ ! -z "$NEWFILENAME" ]; then
-        mv -v "${filename}.pdf" "${NEWFILENAME}.pdf"
-        mv -v "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
+    if [ -n "$NEWFILENAME" ]; then
+        mv -vi "${filename}.pdf" "${NEWFILENAME}.pdf"
+        mv -vi "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
         filename="${NEWFILENAME}"
     else
         rm -v "${filename}.pdf" "${filename}.tar.gz"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -27,12 +27,10 @@ else
 fi
 
 # Check if ssh configuration for "remarkable" exists
-grep -Fxq "host remarkable" ~/.ssh/config
-if [ $? -eq 0 ]; then
-    SSH_IP="root@remarkable"
-else
-    SSH_IP="root@10.11.99.1"
-fi
+[ "$1" = "-r" ] || { echo 'Missing -r ADDRESS'; exit 1; }
+shift
+SSH_IP="root@$1"
+shift
 
 # Start SSH in ControlMaster mode
 control_path_dir=$(mktemp -d --suffix=ssh_remark)
@@ -113,7 +111,7 @@ else
 fi
 
 # Strip .pdf suffix if it already exists (document vs. notebook)
-filename=$(basename -s .pdf ${filename//\"/})
+filename=$(basename -s .pdf "${filename//\"/}")
 
 # Use multistamp instead of multibackground to preserve transparency
 pdftk "${tmpfolder}"/background.pdf multistamp "${tmpfolder}"/foreground.pdf output "${filename}.pdf"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -7,6 +7,64 @@
 # - rsvg-convert (optional, to avoid rasterizing of lines)
 # - gs & pdfinfo (optional, to account for original pdf size)
 
+function rmtgrep {
+    RET_MATCH="$(${SSH_CMD} "$SSH_REMOTE" "/bin/egrep -$1 '$2' $3")"
+    echo "/bin/egrep -$1 '$2' $3: $RET_MATCH"
+}
+
+declare -A DOCUMENTS_NAMES
+declare -A DOCUMENTS_DATES
+
+function find_document {
+    OLD_IFS=$IFS
+    IFS='/' _PATH=(${2#/}) # Sort path into array
+    IFS=$OLD_IFS
+
+    MATCH="${_PATH[$3]}"
+    [ ${MATCH: -1} == "$" ] && MATCH="${MATCH:0:-1}" || MATCH="${MATCH}.*"
+    [ ${MATCH:0:1} == "^" ] && MATCH="${MATCH:1}" || MATCH=".*${MATCH}"
+    rmtgrep "ile" "\"visibleName\": \"${MATCH}\"" "/home/root/.local/share/remarkable/xochitl/*.metadata"
+    echo $RET_MATCH
+    matches_by_name="$RET_MATCH"
+
+    for metadata_path in $matches_by_name; do
+
+        metadata="$(${SSH_CMD} "$SSH_REMOTE" "cat $metadata_path")"
+
+        if ! echo "$metadata" | grep -qF "\"parent\": \"$1\""; then
+            continue
+        fi
+
+        if echo "$metadata" | grep -qF '"deleted": true'; then
+            continue
+        fi
+
+        if [[ "$(expr $3 + 1)" -eq "${#_PATH[@]}" ]]; then
+            if echo "$metadata" | grep -qF '"type": "DocumentType"'; then
+                UUID="$(basename "$metadata_path" .metadata)"
+                NAME="$(echo "$metadata" | grep '"visibleName"' | sed 's/^.*: \+"\([^"]\+\)"/\1/g')"
+                IDATE="$(echo "$metadata" | grep '"lastModified"' | egrep -o '[0-9]*')"
+                STRDATE="$(date -d @$(expr ${IDATE} / 1000) '+%Y-%m-%d %H:%M:%S')"
+                DOCUMENTS_NAMES["$UUID"]="$NAME"
+                DOCUMENTS_DATES["$UUID"]="$STRDATE"
+            fi
+        else
+            if echo "$metadata" | grep -qF '"type": "CollectionType"'; then
+                find_document "$(basename "$metadata_path" .metadata)" "$2" "$(expr $3 + 1)"
+            fi
+        fi
+
+    done
+}
+
+# Kills SSH session and exits with return 1
+function exit_failed {
+    ${SSH_CMD} -O exit "$SSH_REMOTE"
+    exit 1
+}
+
+
+# Usage
 if [[ $# -eq 0 ]] ; then
     echo "Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments"
     echo "You can additionally append the -c argument for coloured annotations."
@@ -25,54 +83,119 @@ else
     rM2svg_cmd="rM2svg"
 fi
 
-# Check if ssh configuration for "remarkable" exists
-[ "$1" = "-r" ] || { echo 'Missing -r ADDRESS'; exit 1; }
-shift
-SSH_IP="root@$1"
-shift
-
-# Start SSH in ControlMaster mode
-ssh_cmd="ssh -o ControlPersist=10s"
-scp_cmd=scp
-rm_tmpfolders="rm -Rf \"${tmpfolder}\""
-
-grep ControlPath ~/.ssh/config >/dev/null
-if [ ! $? -eq 0 ]; then
-    control_path_dir=$(mktemp -d --suffix=ssh_remark)
-    control_options="-o ControlPath=$control_path_dir/%h_%p_%r"
-    rm_tmpfolders="${rm_tmpfolders} \"${control_path_dir}\""
-    ssh_cmd="${ssh_cmd} ${control_options}"
-    scp_cmd="${scp_cmd} ${control_options}"    
-fi
-${ssh_cmd} ${SSH_IP} exit
-
-# Getting the notebook prefix (Newest notebook matching the name)
-id=$(${ssh_cmd} -M ${SSH_IP} "ls -rt .local/share/remarkable/xochitl/*.metadata | xargs fgrep -l $1" | tail -n1 | cut -d. -f1,2)
-
-test -z "$id" && exit 1
+path="$1"
 
 tmpfolder=$(mktemp -d)
+echo "Using temp folder '$tmpfolder'"
 
-# Getting notebook data
-${scp_cmd} -q ${SSH_IP}:"${id}".{lines,pagedata,metadata} "${tmpfolder}"/
+if [ -f "$path" ]; then
+    tar -xvzf "$path" -C "$tmpfolder"
+    filename="$(basename $path .tar.gz)"
 
-# Copy underyling document pdf if it exists
-${ssh_cmd} -q ${SSH_IP} "[[ -f "${id}.pdf" ]]" && ${scp_cmd} -q ${SSH_IP}:"${id}.pdf" "${tmpfolder}"
+else
+
+    # Establish remote connection
+    SSH_HOST="10.11.99.1"
+    [ "$1" = "-r" ] && shift && SSH_HOST="$1" && shift
+    SSH_REMOTE="root@${SSH_HOST}"
+    SSH_CMD="ssh -S remarkable-ssh"
+    SCP_CMD="scp -o ControlPath=remarkable-ssh"
+    ${SSH_CMD} -o ConnectTimeout=1 -M -f -q ${SSH_REMOTE} -N
+    [ ! $? -eq 0 ] && echo "Failed to establish connection with the device!" && exit 1
+
+    # Search for given pattern
+    echo "Searching for '$path'"
+    find_document "" "$path" 0
+
+    DOCUMENTS_UUIDS=(${!DOCUMENTS_NAMES[@]})
+    echo "${#DOCUMENTS_UUIDS[@]}"
+    echo "${DOCUMENTS_UUIDS[@]}"
+
+    # Entry not found
+    if [ "${#DOCUMENTS_UUIDS[@]}" -eq 0 ]; then
+        echo "repull: Unable to find document: $path"
+        exit_failed
+    fi
+
+    # Multiple entries match
+    if [ "${#DOCUMENTS_UUIDS[@]}" -gt 1 ]; then
+        echo "'$path' matches multiple files!"
+
+        while true; do
+            echo
+
+            # Display file id's from most recently modified to oldest
+            for (( i=0; i<${#DOCUMENTS_UUIDS[@]}; i++ )); do
+                UUID=${DOCUMENTS_UUIDS[$i]}
+                NAME=${DOCUMENTS_NAMES[$UUID]}
+                STRDATE=${DOCUMENTS_DATES[$UUID]}
+                echo -e "$(expr $i + 1). - $UUID - $NAME - $STRDATE"
+            done
+
+            echo
+            read -rp "Select your target: " INPUT
+            echo
+
+            if [[ "$INPUT" -gt 0  && "$INPUT" -lt $(expr $i + 1) ]]; then
+                OUTPUT_UUID="${DOCUMENTS_UUIDS[(($INPUT-1))]}"
+                break
+            fi
+
+            echo "Invalid input"
+        done
+
+
+        # Entry found
+    else
+        OUTPUT_UUID="$DOCUMENTS_UUIDS"
+    fi
+
+    echo "UUID : $OUTPUT_UUID"
+    echo "Name : ${DOCUMENTS_NAMES[$UUID]}"
+
+
+    UUID_PATH="/home/root/.local/share/remarkable/xochitl/${OUTPUT_UUID}"
+    # Getting notebook data
+    ${SCP_CMD} -rp ${SSH_REMOTE}:"$UUID_PATH"{,.content,.pagedata,.metadata} "${tmpfolder}"/
+    [ ! $? -eq 0 ] && echo "Failed to get notebook data" && exit 1
+
+    # Copy underyling document pdf if it exists
+    ${SSH_CMD} ${SSH_REMOTE} "[[ -f "${UUID_PATH}.pdf" ]]"
+    if [ $? -eq 0 ]; then
+        ${SCP_CMD} ${SSH_REMOTE}:"${UUID_PATH}.pdf" "${tmpfolder}"
+        [ ! $? -eq 0 ] && echo "Failed to get underlying pdf document" && exit 1
+    fi
+
+    if [ ! -f "${tmpfolder}"/*.pdf ]; then
+        # Getting template files
+        sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
+            ${SCP_CMD} -T ${SSH_REMOTE}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
+            [ ! $? -eq 0 ] && echo "Failed to download template file '${tpl}'" && exit 1
+        done
+    fi
+
+    filename="${DOCUMENTS_NAMES[$UUID]}"
+    # Strip .pdf suffix if it already exists (document vs. notebook)
+    filename=$(basename -s .pdf "${filename//\"/}")
+
+    tar cvzf "${filename}.tar.gz" -C "${tmpfolder}" .
+
+    ${SSH_CMD} -O exit ${SSH_REMOTE}
+
+fi
 
 # Fix for single page notebooks with no template (empty pagedata file by default)
-if [ ! -s "${tmpfolder}"/*.pagedata ]
-then
+if [ ! -s "${tmpfolder}"/*.pagedata ]; then
   echo "Blank" > "${tmpfolder}"/*.pagedata
 fi
 
 # Fix empty lines in pagedata files
 sed -i -e "s/^[[:blank:]]*$/Blank/" "${tmpfolder}"/*.pagedata
 
-filename=$(grep -F  '"visibleName"' "${tmpfolder}"/*.metadata | cut -d: -f2- | grep -o '"[^"]*"')
-echo "Exporting notebook ${filename} ($(wc -l "${tmpfolder}"/*.pagedata | cut -d\  -f1) pages)"
+NPAGES="$(wc -l "${tmpfolder}"/*.pagedata | cut -d\  -f1)"
+echo "Exporting '${filename}' (${NPAGES} pages)"
 
-if [ -f "${tmpfolder}"/*.pdf ]
-then
+if [ -f "${tmpfolder}"/*.pdf ]; then
     ln -s "${tmpfolder}/"*.pdf "${tmpfolder}/background_original.pdf"
     echo "Found underlying document PDF, using as background."
 
@@ -100,17 +223,21 @@ then
         ln -s ${tmpfolder}/background_original.pdf ${tmpfolder}/background.pdf
     fi
 else
-    # Getting template files
-    sort -u "${tmpfolder}"/*.pagedata | while read -r tpl; do
-    ${scp_cmd} -q ${SSH_IP}:"'/usr/share/remarkable/templates/${tpl}.png'" "${tmpfolder}"/
-    done
 
     # Generate a PDF file out of the templates
     sed -e "s|^|\"${tmpfolder}\"/\"|" -e 's|$|.png"|' "${tmpfolder}"/*.pagedata | tr '\n' ' ' | sed -e "s|$|-transparent white \"${tmpfolder}\"/background.pdf|" | xargs convert
+    [ ! $? -eq 0 ] && echo "Failed to generate a PDF file out of the templates" && exit 1
 fi
 
 # Extract annotations and create a PDF
-$rM2svg_cmd --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
+IPAGE=0
+jq '.pages' sandbox/ad41a482-16ee-4389-a7e2-9f8d444d8518.content | jq '.[]' | while read -r page; do
+    SPAGE="${page:1:${#page}-2}"
+    let IPAGE=IPAGE+1
+    echo "Processing page $IPAGE ($SPAGE)"
+    $rM2svg_cmd --input "${tmpfolder}"/*/"${SPAGE}.rm" --output "${tmpfolder}/foreground$(printf %03d $IPAGE).svg"
+    [ ! $? -eq 0 ] && echo "Failed to generate '${tmpfolder}/foreground$(printf %03d $IPAGE).svg'" && exit 1
+done
 
 # Preprocess foreground*.svg
 # - set stroke-width to 3
@@ -118,12 +245,14 @@ $rM2svg_cmd --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 for f in "${tmpfolder}"/foreground*.svg; do
     # debug
     #cp -v "$f" ~/debug/"$(basename "$f")" 
-    sed -i 's/stroke-width:5/stroke-width:3/g;s/opacity:0.9/opacity:1/g' "$f"
+    sed -i 's/stroke-width\:[\.0-9]\+/stroke-width:3/g;s/opacity:0.9/opacity:1/g' "$f"
+    [ ! $? -eq 0 ] && echo "Failed to reset stroke-width and opacity in '$f'" && exit 1
 done
 # - optimize svg with svgo
 if command -v "svgo" > /dev/null; then
     for f in "${tmpfolder}"/foreground*.svg; do
         svgo -i "$f"
+        [ ! $? -eq 0 ] && echo "Failed to optimize svg '$f'" && exit 1
     done
 fi
 
@@ -131,22 +260,23 @@ fi
 if command -v "inkscape" > /dev/null; then
     for f in "${tmpfolder}"/foreground*.svg; do
         inkscape "$f" -d 200 --export-pdf="${f%.svg}.pdf"
+        [ ! $? -eq 0 ] && echo "Failed to convert to pdf via inkscape '$f'" && exit 1
     done
     pdftk "${tmpfolder}"/foreground*.pdf cat output "${tmpfolder}"/foreground.pdf
+    [ ! $? -eq 0 ] && echo "Failed to merge inkscape pdfs" && exit 1
 elif command -v "rsvg-convert" > /dev/null; then
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
+    [ ! $? -eq 0 ] && echo "Failed to convert to pdf via rsvg-convert" && exit 1
 else
     convert -density 100 "${tmpfolder}"/foreground*.svg -transparent white "${tmpfolder}"/foreground.pdf
+    [ ! $? -eq 0 ] && echo "Failed to convert to pdf via convert" && exit 1
 fi
-
-# Strip .pdf suffix if it already exists (document vs. notebook)
-filename=$(basename -s .pdf "${filename//\"/}")
 
 # Use multistamp instead of multibackground to preserve transparency
 pdftk "${tmpfolder}"/background.pdf multistamp "${tmpfolder}"/foreground.pdf output "${filename}.pdf"
+[ ! $? -eq 0 ] && echo "Failed to merge background and foreground pdfs" && exit 1
 
 filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
 echo "Written ${filesize} to ${filename}.pdf"
 
-${ssh_cmd} -O exit ${SSH_IP}
-${rm_tmpfolders}
+#rm -Rfv "${tmpfolder}"

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -7,6 +7,71 @@
 # - rsvg-convert (optional, to avoid rasterizing of lines)
 # - gs & pdfinfo (optional, to account for original pdf size)
 
+
+ASK_RENAME=""
+COLOR_ANNOTATIONS=""
+SSH_HOST="10.11.99.1"
+path=""
+STROKE_WIDTH="3"
+OPACITY="1"
+bad_args=""
+arg_num=0
+KEEP_TEMPDIR=""
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -n|--askrename)
+            ASK_RENAME=true
+            shift
+            ;;
+        -c|--coloured_annotations)
+            COLOR_ANNOTATIONS=true
+            shift
+            ;;
+        -k|--keep_tempdir)
+            KEEP_TEMPDIR=true
+            shift
+            ;;
+        -r|--remoteip)
+            SSH_HOST="$2"
+            shift
+            shift
+            ;;
+        -w|--strokewidth)
+            STROKE_WIDTH="$2"
+            shift
+            shift
+            ;;
+        -o|--opacity)
+            OPACITY="$2"
+            shift
+            shift
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            bad_args=TRUE
+            ;;
+        *)
+            arg_num=$(( $arg_num + 1 ))
+            case $arg_num in
+                1)
+                    path="$1"
+                    shift
+                    ;;
+                *)
+                    bad_args=TRUE
+            esac
+            ;;
+    esac
+done
+
+if [[ $bad_args == TRUE || $arg_num < 1 ]]; then
+    echo "Usage: $(basename "$0") [--askrename|-n] [--remoteip|-r STR] [--strokewidth|-w INT] [--opacity|-o FLOAT] [--coloured_annotations|-c] [--keep_tempdir|-k] <document-name-match|tar.gz-file>"
+    exit 1
+fi
+
+
 function rmtgrep {
     RET_MATCH="$(${SSH_CMD} "$SSH_REMOTE" "/bin/egrep -$1 '$2' $3")"
     echo "/bin/egrep -$1 '$2' $3: $RET_MATCH"
@@ -41,12 +106,12 @@ function find_document {
 
         if [[ "$(expr $3 + 1)" -eq "${#_PATH[@]}" ]]; then
             if echo "$metadata" | grep -qF '"type": "DocumentType"'; then
-                UUID="$(basename "$metadata_path" .metadata)"
+                _UUID="$(basename "$metadata_path" .metadata)"
                 NAME="$(echo "$metadata" | grep '"visibleName"' | sed 's/^.*: \+"\([^"]\+\)"/\1/g')"
                 IDATE="$(echo "$metadata" | grep '"lastModified"' | egrep -o '[0-9]*')"
                 STRDATE="$(date -d @$(expr ${IDATE} / 1000) '+%Y-%m-%d %H:%M:%S')"
-                DOCUMENTS_NAMES["$UUID"]="$NAME"
-                DOCUMENTS_DATES["$UUID"]="$STRDATE"
+                DOCUMENTS_NAMES["$_UUID"]="$NAME"
+                DOCUMENTS_DATES["$_UUID"]="$STRDATE"
             fi
         else
             if echo "$metadata" | grep -qF '"type": "CollectionType"'; then
@@ -64,13 +129,6 @@ function exit_failed {
 }
 
 
-# Usage
-if [[ $# -eq 0 ]] ; then
-    echo "Usage: ./exportNotebook (Partial)NotebookName AdditionalrM2svgArguments"
-    echo "You can additionally append the -c argument for coloured annotations."
-    exit 0
-fi
-
 # Make sure we have rM2svg
 command -v rM2svg >/dev/null 2>&1
 if [[ $? -ne 0 ]]; then
@@ -83,7 +141,7 @@ else
     rM2svg_cmd="rM2svg"
 fi
 
-path="$1"
+[ ! -z $COLOR_ANNOTATIONS ] && rM2svg_cmd="$rM2svg_cmd -c"
 
 tmpfolder=$(mktemp -d)
 echo "Using temp folder '$tmpfolder'"
@@ -95,8 +153,6 @@ if [ -f "$path" ]; then
 else
 
     # Establish remote connection
-    SSH_HOST="10.11.99.1"
-    [ "$1" = "-r" ] && shift && SSH_HOST="$1" && shift
     SSH_REMOTE="root@${SSH_HOST}"
     SSH_CMD="ssh -S remarkable-ssh"
     SCP_CMD="scp -o ControlPath=remarkable-ssh"
@@ -126,10 +182,10 @@ else
 
             # Display file id's from most recently modified to oldest
             for (( i=0; i<${#DOCUMENTS_UUIDS[@]}; i++ )); do
-                UUID=${DOCUMENTS_UUIDS[$i]}
-                NAME=${DOCUMENTS_NAMES[$UUID]}
-                STRDATE=${DOCUMENTS_DATES[$UUID]}
-                echo -e "$(expr $i + 1). - $UUID - $NAME - $STRDATE"
+                _UUID=${DOCUMENTS_UUIDS[$i]}
+                NAME=${DOCUMENTS_NAMES[$_UUID]}
+                STRDATE=${DOCUMENTS_DATES[$_UUID]}
+                echo -e "$(expr $i + 1). - $_UUID - $NAME - $STRDATE"
             done
 
             echo
@@ -137,7 +193,8 @@ else
             echo
 
             if [[ "$INPUT" -gt 0  && "$INPUT" -lt $(expr $i + 1) ]]; then
-                OUTPUT_UUID="${DOCUMENTS_UUIDS[(($INPUT-1))]}"
+                let INPUT=INPUT-1
+                OUTPUT_UUID="${DOCUMENTS_UUIDS[$INPUT]}"
                 break
             fi
 
@@ -151,7 +208,7 @@ else
     fi
 
     echo "UUID : $OUTPUT_UUID"
-    echo "Name : ${DOCUMENTS_NAMES[$UUID]}"
+    echo "Name : ${DOCUMENTS_NAMES[$OUTPUT_UUID]}"
 
 
     UUID_PATH="/home/root/.local/share/remarkable/xochitl/${OUTPUT_UUID}"
@@ -174,7 +231,7 @@ else
         done
     fi
 
-    filename="${DOCUMENTS_NAMES[$UUID]}"
+    filename="${DOCUMENTS_NAMES[$OUTPUT_UUID]}"
     # Strip .pdf suffix if it already exists (document vs. notebook)
     filename=$(basename -s .pdf "${filename//\"/}")
 
@@ -240,12 +297,10 @@ jq '.pages' "${tmpfolder}"/*.content | jq '.[]' | while read -r page; do
 done
 
 # Preprocess foreground*.svg
-# - set stroke-width to 3
-# - set opacity to 1
 for f in "${tmpfolder}"/foreground*.svg; do
     # debug
     #cp -v "$f" ~/debug/"$(basename "$f")" 
-    sed -i 's/stroke-width\:[\.0-9]\+/stroke-width:3/g;s/opacity:0.9/opacity:1/g' "$f"
+    sed -i "s/stroke-width\:[\.0-9]\+/stroke-width:${STROKE_WIDTH}/g;s/opacity\:[\.0-9]\+/opacity:${OPACITY}/g" "$f"
     [ ! $? -eq 0 ] && echo "Failed to reset stroke-width and opacity in '$f'" && exit 1
 done
 # - optimize svg with svgo
@@ -277,6 +332,19 @@ pdftk "${tmpfolder}"/background.pdf multistamp "${tmpfolder}"/foreground.pdf out
 [ ! $? -eq 0 ] && echo "Failed to merge background and foreground pdfs" && exit 1
 
 filesize=$(ls -la "${filename}.pdf" | awk '{print $5}' | numfmt --to=iec-i --suffix=B --format="%.3f")
+
+if [ ! -z $ASK_RENAME ]; then
+    xdg-open "${filename}.pdf"
+    echo
+    read -rp "New name (w/o extension): " NEWFILENAME
+    echo
+    mv -v "${filename}.pdf" "${NEWFILENAME}.pdf"
+    mv -v "${filename}.tar.gz" "${NEWFILENAME}.tar.gz"
+    filename="${NEWFILENAME}"
+fi
+
 echo "Written ${filesize} to ${filename}.pdf"
 
-#rm -Rfv "${tmpfolder}"
+if [ -z $KEEP_TEMPDIR ]; then
+    rm -Rfv "${tmpfolder}"
+fi

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -17,7 +17,7 @@ fi
 command -v rM2svg >/dev/null 2>&1
 if [[ $? -ne 0 ]]; then
     rM2svg_cmd="$(dirname `readlink -f $0`)/rM2svg"
-    if [[ ! -x ${rM2svg_cmd} ]]; then
+    if [ ! -x "$rM2svg_cmd" ]; then
         echo "Cannot find rM2svg"
         exit 1
     fi
@@ -112,9 +112,27 @@ fi
 # Extract annotations and create a PDF
 $rM2svg_cmd --input "${tmpfolder}"/*.lines --output "${tmpfolder}/foreground" $2
 
+# Preprocess foreground*.svg
+# - set stroke-width to 3
+# - set opacity to 1
+for f in "${tmpfolder}"/foreground*.svg; do
+    # debug
+    #cp -v "$f" ~/debug/"$(basename "$f")" 
+    sed -i 's/stroke-width:5/stroke-width:3/g;s/opacity:0.9/opacity:1/g' "$f"
+done
+# - optimize svg with svgo
+if command -v "svgo" > /dev/null; then
+    for f in "${tmpfolder}"/foreground*.svg; do
+        svgo -i "$f"
+    done
+fi
 
+# Convert svg to pdf
 if command -v "inkscape" > /dev/null; then
-    inkscape "${tmpfolder}"/foreground*.svg --export-pdf="${tmpfolder}"/foreground.pdf
+    for f in "${tmpfolder}"/foreground*.svg; do
+        inkscape "$f" -d 200 --export-pdf="${f%.svg}.pdf"
+    done
+    pdftk "${tmpfolder}"/foreground*.pdf cat output "${tmpfolder}"/foreground.pdf
 elif command -v "rsvg-convert" > /dev/null; then
     rsvg-convert -a -f pdf "${tmpfolder}"/foreground*.svg -o "${tmpfolder}"/foreground.pdf
 else

--- a/tools/exportNotebook
+++ b/tools/exportNotebook
@@ -11,6 +11,7 @@
 ASK_RENAME=""
 COLOR_ANNOTATIONS=""
 SSH_HOST="10.11.99.1"
+SSH_TIMEOUT=1
 path=""
 STROKE_WIDTH="3"
 OPACITY="1"
@@ -35,6 +36,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -r|--remoteip)
             SSH_HOST="$2"
+            SSH_TIMEOUT=10
             shift
             shift
             ;;
@@ -160,7 +162,7 @@ else
     SSH_REMOTE="root@${SSH_HOST}"
     SSH_CMD="ssh -S remarkable-ssh"
     SCP_CMD="scp -o ControlPath=remarkable-ssh"
-    ${SSH_CMD} -o ConnectTimeout=1 -M -f -q ${SSH_REMOTE} -N
+    ${SSH_CMD} -o ConnectTimeout=${SSH_TIMEOUT} -M -f -q ${SSH_REMOTE} -N
     [ ! $? -eq 0 ] && echo "Failed to establish connection with the device!" && exit 1
 
     # Search for given pattern
@@ -366,7 +368,7 @@ if [ -n "$ASK_RENAME" ]; then
     xdg-open "${filename}.pdf"
     [ -n "$OUTPUT_UUID" ] && echo "Last modified: ${DOCUMENTS_DATES[$OUTPUT_UUID]}"
     echo
-    read -rp "New name w/o extension, '!rm' to delete files, Enter to skip: " NEWFILENAME
+    read -rp "New name w/o extension, '!rm' to delete '${filename}.{pdf,tar.gz}', Enter to skip: " NEWFILENAME
     echo
     if [ -n "$NEWFILENAME" ]; then
         if [ "$NEWFILENAME" == "!rm" ]; then

--- a/tools/rM2svg
+++ b/tools/rM2svg
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Script for converting reMarkable tablet ".rm" files to SVG image.
-# this works for the new *.rm format, where each page is a seperate file
+# this works for the new *.rm format, where each page is a separate file
 # credits to
 # https://github.com/lschwetlick/maxio/tree/master/tools
 # which in turn credits

--- a/tools/rM2svg
+++ b/tools/rM2svg
@@ -1,42 +1,51 @@
 #!/usr/bin/env python3
+#
+# Script for converting reMarkable tablet ".rm" files to SVG image.
+# this works for the new *.rm format, where each page is a seperate file
+# credit for updating goes to
+# https://github.com/jmiserez/maxio/blob/ee15bcc86e4426acd5fc70e717468862dce29fb8/tmp-rm16-ericsfraga-rm2svg.py
+#
+
 import sys
 import struct
 import os.path
 import argparse
 
 
-__prog_name__ = "rM2svg"
-__version__ = "0.0.1beta"
+__prog_name__ = "rm2svg"
+__version__ = "0.0.2"
 
 
 # Size
-x_width = 1404
-y_width = 1872
+default_x_width = 1404
+default_y_width = 1872
 
 # Mappings
 stroke_colour = {
-    0: "black",
-    1: "grey",
-    2: "white",
-    }
-
+    0 : "black",
+    1 : "grey",
+    2 : "white",
+}
 '''stroke_width={
-    0x3ff00000: 2,
-    0x40000000: 4,
-    0x40080000: 8,
+    0x3ff00000 : 2,
+    0x40000000 : 4,
+    0x40080000 : 8,
 }'''
 
 
 def main():
     parser = argparse.ArgumentParser(prog=__prog_name__)
-    parser.add_argument("-1",
-                        "--singlefile",
-                        help="Enable multipage svg file",
-                        action='store_true',
-                        )
+    parser.add_argument('--height',
+                        help='Desired height of image',
+                        type=float,
+                        default=default_y_width)
+    parser.add_argument('--width',
+                        help='Desired width of image',
+                        type=float,
+                        default=default_x_width)
     parser.add_argument("-i",
                         "--input",
-                        help=".lines input file",
+                        help=".rm input file",
                         required=True,
                         metavar="FILENAME",
                         #type=argparse.FileType('r')
@@ -60,17 +69,19 @@ def main():
 
     if not os.path.exists(args.input):
         parser.error('The file "{}" does not exist!'.format(args.input))
-
     if args.coloured_annotations:
-        global stroke_colour
-        stroke_colour = {
-            0: "blue",
-            1: "red",
-            2: "white",
-            3: "yellow"
-        }
+        set_coloured_annots()
+    rm2svg(args.input, args.output, args.coloured_annotations,
+           args.width, args.height)
 
-    lines2svg(args.input, args.output, args.singlefile, args.coloured_annotations)
+def set_coloured_annots():
+    global stroke_colour
+    stroke_colour = {
+        0: "blue",
+        1: "red",
+        2: "white",
+        3: "yellow"
+    }
 
 
 def abort(msg):
@@ -78,131 +89,130 @@ def abort(msg):
     sys.exit(1)
 
 
-def lines2svg(input_file, output_name, singlefile, coloured_annotations=False):
+def rm2svg(input_file, output_name, coloured_annotations=False,
+           x_width=default_x_width, y_width=default_y_width):
     # Read the file in memory. Consider optimising by reading chunks.
+    if coloured_annotations:
+        set_coloured_annots()
+
     with open(input_file, 'rb') as f:
         data = f.read()
     offset = 0
 
-    if output_name.endswith(".svg") and not singlefile:
-        output_name = output_name[:-4]
-
     # Is this a reMarkable .lines file?
-    expected_header=b'reMarkable lines with selections and layers'
+    expected_header=b'reMarkable .lines file, version=3          '
     if len(data) < len(expected_header) + 4:
         abort('File too short to be a valid file')
 
     fmt = '<{}sI'.format(len(expected_header))
-    header, npages = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
-    if header != expected_header or npages < 1:
-        abort('Not a valid reMarkable file: <header={}><npages={}>'.format(header, npages))
+    header, nlayers = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
+    # print('header={} nlayers={}'.format(header, nlayers))
+    if header != expected_header or nlayers < 1:
+        abort('Not a valid reMarkable file: <header={}> <nlayers={}'.format(header, nlayers))
 
-    if singlefile:
-        output = open(output_name, 'w')
-        output.write('<svg xmlns="http://www.w3.org/2000/svg" height="{}" width="{}">'.format(y_width, x_width)) # BEGIN Notebook
-        output.write('''
-            <script type="application/ecmascript"> <![CDATA[
-                var visiblePage = 'p0';
-                function goToPage(page) {
-                    document.getElementById(visiblePage).setAttribute('style', 'display: none');
-                    document.getElementById(page).setAttribute('style', 'display: inline');
-                    visiblePage = page;
-                }
-            ]]> </script>
-        ''')
+    output = open(output_name, 'w')
+    output.write('<svg xmlns="http://www.w3.org/2000/svg" height="{}" width="{}">'.format(y_width, x_width)) # BEGIN Notebook
+    output.write('''
+        <script type="application/ecmascript"> <![CDATA[
+            var visiblePage = 'p1';
+            function goToPage(page) {
+                document.getElementById(visiblePage).setAttribute('style', 'display: none');
+                document.getElementById(page).setAttribute('style', 'display: inline');
+                visiblePage = page;
+            }
+        ]]> </script>
+    ''')
 
     # Iterate through pages (There is at least one)
-    for page in range(npages):
-        if singlefile:
-            output.write('<g id="p{}" style="display:{}">'.format(page, 'none' if page != 0 else 'inline')) # Opening page group, visible only for the first page.
-        else:
-            output = open("{}_{:02}.svg".format(output_name, page+1), 'w')
-            output.write('<svg xmlns="http://www.w3.org/2000/svg" height="{}" width="{}">\n'.format(y_width, x_width)) # BEGIN page
+    output.write('<g id="p1" style="display:inline">')
+    # Iterate through layers on the page (There is at least one)
+    for layer in range(nlayers):
+        # print('New layer')
+        fmt = '<I'
+        (nstrokes,) = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
 
-        fmt = '<BBH' # TODO might be 'I'
-        nlayers, b_unk, h_unk = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
-        if b_unk != 0 or h_unk != 0: # Might indicate which layers are visible.
-            print('Unexpected value on page {} after nlayers'.format(page + 1))
+        # print('nstrokes={}'.format(nstrokes))
+        # Iterate through the strokes in the layer (If there is any)
+        for stroke in range(nstrokes):
+            fmt = '<IIIfI'
+            pen, colour, i_unk, width, nsegments = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
+            # print('pen={} colour={} i_unk={} width={} nsegments={}'.format(pen,colour,i_unk,width,nsegments))
+            opacity = 1
+            last_x = -1.; last_y = -1.
+            #if i_unk != 0: # No theory on that one
+                #print('Unexpected value at offset {}'.format(offset - 12))
+            if pen == 0 or pen == 1:
+                pass # Dynamic width, will be truncated into several strokes
+            elif pen == 2 or pen == 4: # Pen / Fineliner
+                width = 32 * width * width - 116 * width + 107
+            elif pen == 3: # Marker
+                width = 64 * width - 112
+                opacity = 0.9
+            elif pen == 5: # Highlighter
+                width = 30
+                opacity = 0.2
+                if coloured_annotations:
+                    colour = 3
+            elif pen == 6: # Eraser
+                width = 1280 * width * width - 4800 * width + 4510
+                colour = 2
+            elif pen == 7: # Pencil-Sharp
+                width = 16 * width - 27
+                opacity = 0.9
+            elif pen == 8: # Erase area
+                opacity = 0.
+            else: 
+                print('Unknown pen: {}'.format(pen))
+                opacity = 0.
 
-        # Iterate through layers on the page (There is at least one)
-        for layer in range(nlayers):
-            fmt = '<I'
-            (nstrokes,) = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
+            width /= 2.3 # adjust for transformation to A4
+            
+            #print('Stroke {}: pen={}, colour={}, width={}, nsegments={}'.format(stroke, pen, colour, width, nsegments))
+            output.write('<polyline style="fill:none;stroke:{};stroke-width:{:.3f};opacity:{}" points="'.format(stroke_colour[colour], width, opacity)) # BEGIN stroke
 
-            # Iterate through the strokes in the layer (If there is any)
-            for stroke in range(nstrokes):
-                fmt = '<IIIfI'
-                pen, colour, i_unk, width, nsegments = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
-                opacity = 1
-                last_x = -1.; last_y = -1.
-                #if i_unk != 0: # No theory on that one
-                    #print('Unexpected value at offset {}'.format(offset - 12))
-                if pen == 0 or pen == 1:
-                    pass # Dynamic width, will be truncated into several strokes
-                elif pen == 2 or pen == 4: # Pen / Fineliner
-                    width = 32 * width * width - 116 * width + 107
-                elif pen == 3: # Marker
-                    width = 64 * width - 112
-                    opacity = 0.9
-                elif pen == 5: # Highlighter
-                    width = 30
-                    opacity = 0.2
-                    if coloured_annotations:
-                        colour = 3
-                elif pen == 6: # Eraser
-                    width = 1280 * width * width - 4800 * width + 4510
-                    colour = 2
-                elif pen == 7: # Pencil-Sharp
-                    width = 16 * width - 27
-                    opacity = 0.9
-                elif pen == 8: # Erase area
-                    opacity = 0.
+            # Iterate through the segments to form a polyline
+            for segment in range(nsegments):
+                fmt = '<ffffff'
+                xpos, ypos, pressure, tilt, i_unk2, j_unk2 = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
+                # print('(x,y)=({},{})'.format(xpos,ypos))
+                #xpos += 60
+                #ypos -= 20
+                ratio = (y_width/x_width)/(1872/1404)
+                if ratio > 1:
+                    xpos = ratio*((xpos*x_width)/1404)
+                    ypos = (ypos*y_width)/1872
                 else:
-                    print('Unknown pen: {}'.format(pen))
-                    opacity = 0.
+                    xpos = (xpos*x_width)/1404
+                    ypos = (1/ratio)*(ypos*y_width)/1872
+                if pen == 0:
+                    if 0 == segment % 8:
+                        segment_width = (5. * tilt) * (6. * width - 10) * (1 + 2. * pressure * pressure * pressure)
+                        #print('    width={}'.format(segment_width))
+                        output.write('" />\n<polyline style="fill:none;stroke:{};stroke-width:{:.3f}" points="'.format(
+                                    stroke_colour[colour], segment_width)) # UPDATE stroke
+                        if last_x != -1.:
+                            output.write('{:.3f},{:.3f} '.format(last_x, last_y)) # Join to previous segment
+                        last_x = xpos; last_y = ypos
+                elif pen == 1:
+                    if 0 == segment % 8:
+                        segment_width = (10. * tilt -2) * (8. * width - 14)
+                        segment_opacity = (pressure - .2) * (pressure - .2)
+                        #print('    width={}, opacity={}'.format(segment_width, segment_opacity))
+                        output.write('" /><polyline style="fill:none;stroke:{};stroke-width:{:.3f};opacity:{:.3f}" points="'.format(
+                                    stroke_colour[colour], segment_width, segment_opacity)) # UPDATE stroke
+                        if last_x != -1.:
+                            output.write('{:.3f},{:.3f} '.format(last_x, last_y)) # Join to previous segment
+                        last_x = xpos; last_y = ypos
 
-                #print('Stroke {}: pen={}, colour={}, width={}, nsegments={}'.format(stroke, pen, colour, width, nsegments))
-                output.write('<polyline style="fill:none;stroke:{};stroke-width:{:.3f};opacity:{}" points="'.format(stroke_colour[colour], width, opacity)) # BEGIN stroke
+                output.write('{:.3f},{:.3f} '.format(xpos, ypos)) # BEGIN and END polyline segment
 
-                # Iterate through the segments to form a polyline
-                for segment in range(nsegments):
-                    fmt = '<fffff'
-                    xpos, ypos, pressure, tilt, i_unk2 = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
-                    if pen == 0:
-                        if 0 == segment % 8:
-                            segment_width = (5. * tilt) * (6. * width - 10) * (1 + 2. * pressure * pressure * pressure)
-                            #print('    width={}'.format(segment_width))
-                            output.write('" /><polyline style="fill:none;stroke:{};stroke-width:{:.3f}" points="'.format(
-                                        stroke_colour[colour], segment_width)) # UPDATE stroke
-                            if last_x != -1.:
-                                output.write('{:.3f},{:.3f} '.format(last_x, last_y)) # Join to previous segment
-                            last_x = xpos; last_y = ypos
-                    elif pen == 1:
-                        if 0 == segment % 8:
-                            segment_width = (10. * tilt -2) * (8. * width - 14)
-                            segment_opacity = (pressure - .2) * (pressure - .2)
-                            #print('    width={}, opacity={}'.format(segment_width, segment_opacity))
-                            output.write('" /><polyline style="fill:none;stroke:{};stroke-width:{:.3f};opacity:{:.3f}" points="'.format(
-                                        stroke_colour[colour], segment_width, segment_opacity)) # UPDATE stroke
-                            if last_x != -1.:
-                                output.write('{:.3f},{:.3f} '.format(last_x, last_y)) # Join to previous segment
-                            last_x = xpos; last_y = ypos
+            output.write('" />\n') # END stroke
 
-                    output.write('{:.3f},{:.3f} '.format(xpos, ypos)) # BEGIN and END polyline segment
-
-                output.write('" />\n') # END stroke
-
-        if singlefile:
-            # Overlay the page with a clickable rect to flip pages
-            output.write('<rect x="0" y="0" width="{}" height="{}" fill-opacity="0" onclick="goToPage(\'p{}\')" />'.format(x_width, y_width, (page + 1) % npages))
-            output.write('</g>') # Closing page group
-        else:
-            output.write('</svg>') # END page
-            output.close()
-
-    if singlefile:
-        output.write('</svg>') # END notebook
-        output.close()
+    # Overlay the page with a clickable rect to flip pages
+    output.write('<rect x="0" y="0" width="{}" height="{}" fill-opacity="0"/>'.format(x_width, y_width))
+    output.write('</g>') # Closing page group
+    output.write('</svg>') # END notebook
+    output.close()
 
 if __name__ == "__main__":
     main()

--- a/tools/rM2svg
+++ b/tools/rM2svg
@@ -12,10 +12,11 @@ import sys
 import struct
 import os.path
 import argparse
+import re
 
 
 __prog_name__ = "rm2svg"
-__version__ = "0.0.2"
+__version__ = "0.0.2.1"
 
 
 # Size
@@ -102,16 +103,22 @@ def rm2svg(input_file, output_name, coloured_annotations=False,
     offset = 0
 
     # Is this a reMarkable .lines file?
-    expected_header=b'reMarkable .lines file, version=3          '
+    
+    expected_header=b'reMarkable .lines file, version=#          '
     if len(data) < len(expected_header) + 4:
         abort('File too short to be a valid file')
 
     fmt = '<{}sI'.format(len(expected_header))
     header, nlayers = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
     # print('header={} nlayers={}'.format(header, nlayers))
-    if header != expected_header or nlayers < 1:
+    re_expected_header = f"^{str(expected_header,'utf-8').replace('#','([345])')}$"
+    re_expected_header_match = re.match(re_expected_header, str(header ,'utf-8'))
+    if (re_expected_header is None) or (nlayers < 1):
         abort('Not a valid reMarkable file: <header={}> <nlayers={}'.format(header, nlayers))
-
+    _stroke_fmt_by_vers = {
+        '3': '<IIIfI',
+	'5': '<IIIfII' }
+    _stroke_fmt = _stroke_fmt_by_vers[re_expected_header_match.groups(1)[0]]
     output = open(output_name, 'w')
     output.write('<svg xmlns="http://www.w3.org/2000/svg" height="{}" width="{}">'.format(y_width, x_width)) # BEGIN Notebook
     output.write('''
@@ -136,8 +143,11 @@ def rm2svg(input_file, output_name, coloured_annotations=False,
         # print('nstrokes={}'.format(nstrokes))
         # Iterate through the strokes in the layer (If there is any)
         for stroke in range(nstrokes):
-            fmt = '<IIIfI'
-            pen, colour, i_unk, width, nsegments = struct.unpack_from(fmt, data, offset); offset += struct.calcsize(fmt)
+            fmt = _stroke_fmt
+            stroke_data = struct.unpack_from(fmt, data, offset)
+            offset += struct.calcsize(fmt)
+            pen, colour, i_unk, width = stroke_data[:4]
+            nsegments = stroke_data[-1]
             # print('pen={} colour={} i_unk={} width={} nsegments={}'.format(pen,colour,i_unk,width,nsegments))
             opacity = 1
             last_x = -1.; last_y = -1.

--- a/tools/rM2svg
+++ b/tools/rM2svg
@@ -2,7 +2,9 @@
 #
 # Script for converting reMarkable tablet ".rm" files to SVG image.
 # this works for the new *.rm format, where each page is a seperate file
-# credit for updating goes to
+# credits to
+# https://github.com/lschwetlick/maxio/tree/master/tools
+# which in turn credits
 # https://github.com/jmiserez/maxio/blob/ee15bcc86e4426acd5fc70e717468862dce29fb8/tmp-rm16-ericsfraga-rm2svg.py
 #
 


### PR DESCRIPTION
Tested with rM v1.7.2.3 and v1.8.1.1. Below the list of major changes

- update rm2svg to a 0.0.2 version found in another fork which seems to work with v3 lines format (https://github.com/lschwetlick/maxio/tree/master/tools)
- use find_document and rmtgrep to find matching documents, the same functions used in repull.sh from https://github.com/reHackable/scripts (eventually I think all these should be consolidated, as many helper functions would be the same)
- output (and support as input) a .tar.gz file with all the original downloaded file from the rM. the idea is that you might want to process them differently at a later time, while meanwhile you might have deleted the files on the device itself. if the .tar.gz file is used as input, no ssh connection to the rM is needed
- in case of multiple matches, show also the visibleName and not only the uuid and lastModDate to help with the selection
- add svg optimization via svgo if present
- add pdf conversion via alternative methods (e.g. I use inkscape as default, as I thought it gave me the best results)
- add some arguments options, hopefully self-explanatory. I confess one might be related to my workflow alone, which is the askrename. In fact, I tend to leave a default name for my notes (e.g. Notebook32), so that looking at the created pdf and being offered a chance of renaming I can replace that without a second cmd.
- overwrite stroke width and opacity to default values (I was unhappy with the default pdf rendering by rM, which looked nice on the device but uglier in the downloaded pdf)
- increase verbosity (this might be eventually controlled with an arg option

I didn't test all corner cases, plus there is plenty of optimizations possible (e.g. pdf pages w/ no annotations are still converted to svg for the final pdftk combinations) but maybe it's a starting point to keep this useful tool current.