### PR TITLE
Add smoothing to strokes

### DIFF
--- a/tools/rM2svg
+++ b/tools/rM2svg
@@ -180,7 +180,7 @@ def rm2svg(input_file, output_name, coloured_annotations=False,
             width /= 2.3 # adjust for transformation to A4
             
             #print('Stroke {}: pen={}, colour={}, width={}, nsegments={}'.format(stroke, pen, colour, width, nsegments))
-            output.write('<polyline style="fill:none;stroke:{};stroke-width:{:.3f};opacity:{}" points="'.format(stroke_colour[colour], width, opacity)) # BEGIN stroke
+            output.write('<polyline style="fill:none;stroke:{};stroke-width:{:.3f};opacity:{};stroke-linejoin:round" points="'.format(stroke_colour[colour], width, opacity)) # BEGIN stroke
 
             # Iterate through the segments to form a polyline
             for segment in range(nsegments):


### PR DESCRIPTION
This sets the line joins to `round` so the strokes can appear smoother and avoids jagged lines.

See the example below:

Before:
![before](https://user-images.githubusercontent.com/16529252/166876386-258d040b-e7e3-4c4e-9172-154439b008e0.svg)
After:
![after](https://user-images.githubusercontent.com/16529252/166876412-fcfd01a6-0afb-4eae-aeeb-11e853e5b680.svg)

